### PR TITLE
Fork new cluster workers on exit event

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -60,7 +60,7 @@ cluster.on('listening', stopNextWorker)
 // A worker has disconnected either because the process was killed
 // or we are processing the workersToStop array restarting each process
 // In either case, we will fork any workers needed
-cluster.on('disconnect', forkNewWorkers)
+cluster.on('exit', forkNewWorkers)
 
 // HUP signal sent to the master process to start restarting all the workers sequentially
 process.on('SIGHUP', function() {


### PR DESCRIPTION
Disconnect is triggered before worker is dead/killed. Call to forkNewWorkers doesn't create a new worker as the max workers already exist. No new workers are created so the listening event is never triggered to stopNextWorker.

https://nodejs.org/api/cluster.html#cluster_event_disconnect